### PR TITLE
Support installation via go get by changing module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module aws-sso-fetcher
+module github.com/flyinprogrammer/aws-sso-fetcher
 
 go 1.14
 


### PR DESCRIPTION
Hi there,

Great tool - made it super easy to get aws sso working with Terraform. 

Only slightly annoying thing is that I couldn't do `go get github.com/flyinprogrammer/aws-sso-fetcher` to install it quickly, and I had to clone and build it. My change to the module name will allow people to install this with one command.

Here is the error when currently trying to do `go get`:

```
go: github.com/flyinprogrammer/aws-sso-fetcher upgrade => v0.0.1
go get: github.com/flyinprogrammer/aws-sso-fetcher@v0.0.1: parsing go.mod:
	module declares its path as: aws-sso-fetcher
	        but was required as: github.com/flyinprogrammer/aws-sso-fetcher
```

Hope it looks good.

Thanks,
George